### PR TITLE
Various small fixes

### DIFF
--- a/lib/include/execution_tracer.h
+++ b/lib/include/execution_tracer.h
@@ -146,7 +146,7 @@
 #define TRACE_VariableValue(var)    TRACE_Put(                                  \
     ((TRACE_IDCODE_VARIABLE_VALUE << TRACE_IDCODE_Pos) & TRACE_IDCODE_Msk) |    \
     ((((uintptr_t)(&var) - RAM_BASE) << TRACE_DATA_Pos) & TRACE_DATA_Msk));     \
-    TRACE_Put(var)
+    TRACE_Put((uint32_t)var)
 
 /**
  * @brief       Trace a memory mapped peripheral register value
@@ -170,7 +170,7 @@ typedef struct {
 } ExecTracer_t;
 
 
-extern ExecTracer_t m_exec_trace;
+extern volatile ExecTracer_t m_exec_trace;
 
 
 /**

--- a/lib/src/execution_tracer.c
+++ b/lib/src/execution_tracer.c
@@ -10,7 +10,7 @@
 
 _Static_assert(IS_POWER_OF_2(BUFFER_LENGTH_IN_WORDS), "BUFFER_LENGTH_IN_WORDS must be a power of 2");
 
-__NO_INIT ExecTracer_t m_exec_trace;
+__NO_INIT ExecTracer_t volatile m_exec_trace;
 
 void TRACE_Init(void)
 {

--- a/tools/parse_map_file.py
+++ b/tools/parse_map_file.py
@@ -13,7 +13,6 @@ class LinkerSection(Enum):
     BSS = 4
 
 linker_section_ids = {
-    """Dictionary to map map-file section name to enum identifier."""
     ".text": LinkerSection.TEXT,
     ".data": LinkerSection.DATA,
     ".bss": LinkerSection.BSS


### PR DESCRIPTION
The global m_exec_trace structure is now declared volatile. TRACE_VariableValue now casts the trace of the variable itself to uint32_t to prevent compiler warnings when tracing other variable types. The doc string was removed from the linker_section_ids dictionary in parse_map_file.py since it interferes with the dictionary definition.